### PR TITLE
add the node auth token env for docker builds

### DIFF
--- a/.github/workflows/job-docker-build-push.yml
+++ b/.github/workflows/job-docker-build-push.yml
@@ -23,6 +23,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ inputs.imageTagName }}:${{ inputs.version }}


### PR DESCRIPTION
we need to specify it, to get access to the github packages.
If it is not a node build, having it in the env should be fine, since it is a global secret