### PR TITLE
added kube-linter and kube-score pipeline

### DIFF
--- a/.github/workflows/pipeline-k8s-check.yml
+++ b/.github/workflows/pipeline-k8s-check.yml
@@ -24,22 +24,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install Kube-Score
+        run: |
+          curl -LO https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_amd64.tar.gz
+          tar -xzf kube-score_1.18.0_linux_amd64.tar.gz
+          mv kube-score /usr/local/bin/
+
       - name: Install Kube-Linter
         run: |
           curl -LO https://github.com/stackrox/kube-linter/releases/download/v0.6.8/kube-linter-linux.tar.gz
           tar -xzf kube-linter-linux.tar.gz
-          sudo mv kube-linter /usr/local/bin/
-
-      - name: Install Kube-Score
-        run: |
-          curl -LO https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_amd64.tar.gz
-          tar -xzf kube-score_1.18.0_linux_amd64
-          sudo mv kube-score /usr/local/bin/
-
-      - name: Run Kube-Linter
-        run: |
-          kube-linter lint ${{ inputs.kube_lint_target }}
+          mv kube-linter /usr/local/bin/
 
       - name: Run Kube-Score
         run: |
           kube-score score ${{ inputs.kube_score_target }}
+
+      - name: Run Kube-Linter
+        run: |
+          kube-linter lint ${{ inputs.kube_lint_target }}

--- a/.github/workflows/pipeline-k8s-check.yml
+++ b/.github/workflows/pipeline-k8s-check.yml
@@ -5,16 +5,44 @@ name: Kube Checks
 on:
   workflow_call:
     inputs:
-      kube_lint_target:
-        description: 'The directory to run kube-linter'
-        required: false
-        default: "./"
+      # REQUIRED
+      kube_lint_directory:
+        description: 'Path of file or directory to scan with kube-linter'
+        required: true
         type: string
-      kube_score_target:
-        description: 'The yaml or yaml files to run kube-score on'
-        required: false
-        default: "./**/*.y*ml"
+      kube_score_manifests_folders:
+        description: 'An array of relative paths to manifests(not directories) to analyze with kube-score'
+        required: true
         type: string
+
+      # OPTIONAL kube-score
+      kube_score_version:
+        description: 'Version of kube-score to use'
+        required: false
+        default: 'v1.18.0'
+        type: string
+      kube_score_args:
+        description: "You can pass additional flags like --disable-ignore-checks-annotations or --disable-optional-checks-annotations"
+        required: false
+        type: string
+      kube_score_continue_on_error:
+        description: "Continue in case of errors"
+        required: false
+        default: false
+        type: bool
+
+      # OPTIONAL kube-lint
+      kube_lint_version:
+        description: 'kube-linter release version to use'
+        required: false
+        default: "v0.6.8"
+        type: string
+      kube_lint_continue_on_error:
+        description: "Continue in case of errors"
+        required: false
+        default: false
+        type: bool
+
 
 jobs:
   kube-checks:
@@ -24,22 +52,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Kube-Score
-        run: |
-          curl -LO https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_amd64.tar.gz
-          tar -xzf kube-score_1.18.0_linux_amd64.tar.gz
-          mv kube-score /usr/local/bin/
+      - name: kube-score install
+        uses: yokawasa/action-setup-kube-tools@v0.11.1
+        with:
+          kube-score: ${{ inputs.kube_score_version }}
 
-      - name: Install Kube-Linter
+      - name: kube-score run
         run: |
-          curl -LO https://github.com/stackrox/kube-linter/releases/download/v0.6.8/kube-linter-linux.tar.gz
-          tar -xzf kube-linter-linux.tar.gz
-          mv kube-linter /usr/local/bin/
+          kube-score score ${{ inputs.kube_score_manifests_folders }} ${{ inputs.kube_score_args }}
+        continue-on-error:  ${{ inputs.kube_score_continue_on_error }}
 
-      - name: Run Kube-Score
-        run: |
-          kube-score score ${{ inputs.kube_score_target }}
-
-      - name: Run Kube-Linter
-        run: |
-          kube-linter lint ${{ inputs.kube_lint_target }}
+      - name: kube-linter
+        uses: stackrox/kube-linter-action@v1.0.5
+        with:
+          directory: ${{ inputs.kube_lint_directory }}
+          version: ${{ inputs.kube_lint_version }}
+        continue-on-error:  ${{ inputs.kube_lint_continue_on_error }}

--- a/.github/workflows/pipeline-k8s-check.yml
+++ b/.github/workflows/pipeline-k8s-check.yml
@@ -6,11 +6,11 @@ on:
   workflow_call:
     inputs:
       # REQUIRED
-      kube_lint_directory:
+      kube_lint_target_directory:
         description: 'Path of file or directory to scan with kube-linter'
         required: true
         type: string
-      kube_score_manifests_folders:
+      kube_score_target_manifests:
         description: 'An array of relative paths to manifests(not directories) to analyze with kube-score'
         required: true
         type: string
@@ -59,12 +59,12 @@ jobs:
 
       - name: kube-score run
         run: |
-          kube-score score ${{ inputs.kube_score_manifests_folders }} ${{ inputs.kube_score_args }}
+          kube-score score ${{ inputs.kube_score_target_manifests }} ${{ inputs.kube_score_args }}
         continue-on-error:  ${{ inputs.kube_score_continue_on_error }}
 
       - name: kube-linter
         uses: stackrox/kube-linter-action@v1.0.5
         with:
-          directory: ${{ inputs.kube_lint_directory }}
+          directory: ${{ inputs.kube_lint_target_directory }}
           version: ${{ inputs.kube_lint_version }}
         continue-on-error:  ${{ inputs.kube_lint_continue_on_error }}

--- a/.github/workflows/pipeline-k8s-check.yml
+++ b/.github/workflows/pipeline-k8s-check.yml
@@ -1,0 +1,45 @@
+# This workflow performs static code analysis of your Kubernetes object definitions
+# using kube-score and kube-linter tools.
+name: Kube Checks
+
+on:
+  workflow_call:
+    inputs:
+      kube_lint_target:
+        description: 'The directory to run kube-linter'
+        required: false
+        default: "./"
+        type: string
+      kube_score_target:
+        description: 'The yaml or yaml files to run kube-score on'
+        required: false
+        default: "./**/*.y*ml"
+        type: string
+
+jobs:
+  kube-checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Kube-Linter
+        run: |
+          curl -LO https://github.com/stackrox/kube-linter/releases/download/v0.6.8/kube-linter-linux.tar.gz
+          tar -xzf kube-linter-linux.tar.gz
+          sudo mv kube-linter /usr/local/bin/
+
+      - name: Install Kube-Score
+        run: |
+          curl -LO https://github.com/zegl/kube-score/releases/download/v1.18.0/kube-score_1.18.0_linux_amd64.tar.gz
+          tar -xzf kube-score_1.18.0_linux_amd64
+          sudo mv kube-score /usr/local/bin/
+
+      - name: Run Kube-Linter
+        run: |
+          kube-linter lint ${{ inputs.kube_lint_target }}
+
+      - name: Run Kube-Score
+        run: |
+          kube-score score ${{ inputs.kube_score_target }}

--- a/.github/workflows/pipeline-k8s-checks.yml
+++ b/.github/workflows/pipeline-k8s-checks.yml
@@ -22,11 +22,12 @@ on:
         default: 'v1.18.0'
         type: string
       kube_score_args:
-        description: "You can pass additional flags like --disable-ignore-checks-annotations or --disable-optional-checks-annotations"
+        description: 'You can pass additional flags like --disable-ignore-checks-annotations or --disable-optional-checks-annotations'
         required: false
+        default: ''
         type: string
       kube_score_continue_on_error:
-        description: "Continue in case of errors"
+        description: 'Continue in case of errors'
         required: false
         default: false
         type: bool
@@ -35,10 +36,10 @@ on:
       kube_lint_version:
         description: 'kube-linter release version to use'
         required: false
-        default: "v0.6.8"
+        default: 'v0.6.8'
         type: string
       kube_lint_continue_on_error:
-        description: "Continue in case of errors"
+        description: 'Continue in case of errors'
         required: false
         default: false
         type: bool

--- a/.github/workflows/pipeline-k8s-checks.yml
+++ b/.github/workflows/pipeline-k8s-checks.yml
@@ -11,9 +11,9 @@ on:
         required: true
         type: string
       kube_score_target_manifests:
-        description: 'An array of relative paths to manifests (not directories) to analyze with kube-score'
+        description: 'A list(with no commas) of relative paths to manifests (not directories) to analyze with kube-score'
         required: true
-        type: array
+        type: string
 
       # OPTIONAL kube-score
       kube_score_version:
@@ -59,7 +59,7 @@ jobs:
 
       - name: kube-score run
         run: |
-          kube-score score ${{ inputs.kube_score_target_manifests.join(' ') }} ${{ inputs.kube_score_args }}
+          kube-score score ${{ inputs.kube_score_target_manifests }} ${{ inputs.kube_score_args }}
         continue-on-error: ${{ inputs.kube_score_continue_on_error }}
 
       - name: kube-linter

--- a/.github/workflows/pipeline-k8s-checks.yml
+++ b/.github/workflows/pipeline-k8s-checks.yml
@@ -26,11 +26,6 @@ on:
         required: false
         default: ''
         type: string
-      kube_score_continue_on_error:
-        description: 'Continue in case of errors'
-        required: false
-        default: false
-        type: boolean
 
       # OPTIONAL kube-lint
       kube_lint_version:
@@ -38,11 +33,7 @@ on:
         required: false
         default: 'v0.6.8'
         type: string
-      kube_lint_continue_on_error:
-        description: 'Continue in case of errors'
-        required: false
-        default: false
-        type: boolean
+
 
 jobs:
   kube-checks:
@@ -60,11 +51,10 @@ jobs:
       - name: kube-score run
         run: |
           kube-score score ${{ inputs.kube_score_target_manifests }} ${{ inputs.kube_score_args }}
-        continue-on-error: ${{ inputs.kube_score_continue_on_error }}
 
       - name: kube-linter
+        if: always() # run this step even if previous fails
         uses: stackrox/kube-linter-action@v1.0.5
         with:
           directory: ${{ inputs.kube_lint_target_directory }}
           version: ${{ inputs.kube_lint_version }}
-        continue-on-error: ${{ inputs.kube_lint_continue_on_error }}

--- a/.github/workflows/pipeline-k8s-checks.yml
+++ b/.github/workflows/pipeline-k8s-checks.yml
@@ -1,6 +1,6 @@
 # This workflow performs static code analysis of your Kubernetes object definitions
 # using kube-score and kube-linter tools.
-name: Kube Checks
+name: K8S Checks
 
 on:
   workflow_call:

--- a/.github/workflows/pipeline-k8s-checks.yml
+++ b/.github/workflows/pipeline-k8s-checks.yml
@@ -11,9 +11,9 @@ on:
         required: true
         type: string
       kube_score_target_manifests:
-        description: 'An array of relative paths to manifests(not directories) to analyze with kube-score'
+        description: 'An array of relative paths to manifests (not directories) to analyze with kube-score'
         required: true
-        type: string
+        type: array
 
       # OPTIONAL kube-score
       kube_score_version:
@@ -30,7 +30,7 @@ on:
         description: 'Continue in case of errors'
         required: false
         default: false
-        type: bool
+        type: boolean
 
       # OPTIONAL kube-lint
       kube_lint_version:
@@ -42,8 +42,7 @@ on:
         description: 'Continue in case of errors'
         required: false
         default: false
-        type: bool
-
+        type: boolean
 
 jobs:
   kube-checks:
@@ -60,12 +59,12 @@ jobs:
 
       - name: kube-score run
         run: |
-          kube-score score ${{ inputs.kube_score_target_manifests }} ${{ inputs.kube_score_args }}
-        continue-on-error:  ${{ inputs.kube_score_continue_on_error }}
+          kube-score score ${{ inputs.kube_score_target_manifests.join(' ') }} ${{ inputs.kube_score_args }}
+        continue-on-error: ${{ inputs.kube_score_continue_on_error }}
 
       - name: kube-linter
         uses: stackrox/kube-linter-action@v1.0.5
         with:
           directory: ${{ inputs.kube_lint_target_directory }}
           version: ${{ inputs.kube_lint_version }}
-        continue-on-error:  ${{ inputs.kube_lint_continue_on_error }}
+        continue-on-error: ${{ inputs.kube_lint_continue_on_error }}


### PR DESCRIPTION
UPD 18.06:
Tested as a raw direct workflow here: https://github.com/openmfp/extension-content-operator/actions/runs/9562502851/job/26359010609

To handle errors when pipeline will be enabled at the consumer repo we can go two ways:
1. Set `continue-on-error: true` variable, in this case the whole CI will be green, but in Checks annotation section in the very bottom you will se red warnings that steps failed.
2. add `if: always()` to step, in this case it will be executed even if previous step failed.