### PR TITLE
feat: enable multi arch build for docker images to be used in a local environment

### DIFF
--- a/.github/workflows/job-docker-build-push.yml
+++ b/.github/workflows/job-docker-build-push.yml
@@ -31,6 +31,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           push: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ inputs.imageTagName }}:${{ inputs.version }}
           secrets: |
             NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If we want to get started in providing an easy local env for users, we need to make sure, that not only `linux/amd64` for intel based processors are supported but also `linux/arm64` for new apple silicon ones.

This change should ensure, that all images built are available at least for those two platforms