### PR TITLE
ci: testing to run go-test-coverage directly to circumvent go version issue

### DIFF
--- a/.github/workflows/job-golang-test-source.yml
+++ b/.github/workflows/job-golang-test-source.yml
@@ -38,22 +38,11 @@ jobs:
       - name: Test task
         if: ${{ inputs.useTask == true }}
         run: task cover
+      - name: Install Code Coverage
+        run: go install github.com/vladopajic/go-test-coverage/v2@latest
       - name: Check Test Coverage
-        uses: vladopajic/go-test-coverage@v2
+        run: go-test-coverage --threshold-file ${{ inputs. coverageThreasholdFile }} --threshold-package ${{ inputs. coverageThreasholdPackage }} --threshold-total ${{ inputs. coverageThreasholdTotal }} --profile cover.out
         if: ${{ inputs.useLocalCoverageConfig == false }}
-        with:
-          profile: cover.out
-          # local-prefix: github.com/org/project
-          threshold-file: ${{ inputs. coverageThreasholdFile }}
-          threshold-package: ${{ inputs. coverageThreasholdPackage }}
-          threshold-total: ${{ inputs. coverageThreasholdTotal }}
       - name: Check Test Coverage with Config
-        uses: vladopajic/go-test-coverage@v2
+        run: go-test-coverage --threshold-file ${{ inputs. coverageThreasholdFile }} --threshold-package ${{ inputs. coverageThreasholdPackage }} --threshold-total ${{ inputs. coverageThreasholdTotal }} --profile cover.out --config ./.testcoverage.yml
         if: ${{ inputs.useLocalCoverageConfig == true }}
-        with:
-          profile: cover.out
-          config: ./.testcoverage.yml
-          # local-prefix: github.com/org/project
-          threshold-file: ${{ inputs. coverageThreasholdFile }}
-          threshold-package: ${{ inputs. coverageThreasholdPackage }}
-          threshold-total: ${{ inputs. coverageThreasholdTotal }}


### PR DESCRIPTION
This PR avoids the issue reported here: https://github.com/vladopajic/go-test-coverage/issues/89