### PR TITLE
fix: right location to metadata-creation-tool-for-reuse

### DIFF
--- a/.github/workflows/job-license-metadata.yml
+++ b/.github/workflows/job-license-metadata.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Metadata Creation Tool"
     steps:
-      - uses: SAP/metadata-creation-tool-for-reuse@main
+      - uses: SAP-archive/metadata-creation-tool-for-reuse@main
         with:
           repository_url: "${{ github.server_url }}/${{ github.repository }}"
           access_token: "${{ secrets.GH_ACCESS_TOKEN }}"


### PR DESCRIPTION
`metadata-creation-tool-for-reuse` was archived and moved from SAP to SAP-archive organization.

Changes:
- change pointer to metadata-creation-tool-for-reuse