### PR TITLE
ci: removing chart update commands as we'll move the charts to a cent…

### DIFF
--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -5,14 +5,6 @@ on:
       imageTagName:
         required: true
         type: string
-      chartFolder:
-        required: false
-        type: string
-        default: 'chart'
-      additionalTestFilesCommand:
-        required: false
-        type: string
-        default: '-f chart/test-values.yaml'
       useTask:
         required: false
         type: boolean
@@ -37,10 +29,6 @@ on:
         required: false
         type: string
         default: 'main'
-      publishCRDChart:
-        required: false
-        type: boolean
-        default: false
     outputs:
       version:
         description: "The created Version"
@@ -51,13 +39,6 @@ jobs:
     uses: ./.github/workflows/job-create-version.yml
     secrets: inherit
   
-  testChart:
-    uses: ./.github/workflows/job-test-chart.yml
-    with:
-      chartFolder: ${{ inputs.chartFolder }}
-      additionalTestFilesCommand: ${{ inputs.additionalTestFilesCommand }}
-    secrets: inherit
-
   lint:
     uses: ./.github/workflows/job-golang-lint.yml
     with:
@@ -80,16 +61,3 @@ jobs:
       version: ${{ needs.createVersion.outputs.version }}
       release_branch: ${{ inputs.release_branch }}
     secrets: inherit
-
-  release:
-    needs: [createVersion,dockerBuildAndPush,lint,testSource,testChart]
-    uses: ./.github/workflows/job-release-chart.yml
-    secrets: inherit
-    with:
-      updateVersion: true
-      pushTags: true
-      imageTagName: ${{ inputs.imageTagName }}
-      version: ${{ needs.createVersion.outputs.version }}
-      chartFolder: ${{ inputs.chartFolder }}
-      release_branch: ${{ inputs.release_branch }}
-      publishCRDChart: ${{ inputs.publishCRDChart }}

--- a/.github/workflows/pipeline-node-app.yml
+++ b/.github/workflows/pipeline-node-app.yml
@@ -5,17 +5,9 @@ on:
       imageTagName:
         required: true
         type: string
-      chartFolder:
-        required: false
-        type: string
-        default: 'chart'
       componentVersionKey:
         required: true
         type: string
-      additionalTestFilesCommand:
-        required: false
-        type: string
-        default: '-f chart/test-values.yaml'
       release_branch:
         description: 'Name of the release branch'
         required: false
@@ -36,13 +28,6 @@ jobs:
       release_branch: ${{ inputs.release_branch }}
       node_version: ${{ inputs.node_version }}
 
-  testChart:
-    uses: ./.github/workflows/job-test-chart.yml
-    with:
-      chartFolder: ${{ inputs.chartFolder }}
-      additionalTestFilesCommand: ${{ inputs.additionalTestFilesCommand }}
-    secrets: inherit
-
   dockerBuildAndPush:
     needs: [createVersion]
     uses: ./.github/workflows/job-docker-build-push.yml
@@ -51,23 +36,3 @@ jobs:
       version: ${{ needs.createVersion.outputs.version }}
       release_branch: ${{ inputs.release_branch }}
     secrets: inherit
-
-  release:
-    needs: [createVersion,dockerBuildAndPush, test,testChart]
-    uses: ./.github/workflows/job-release-chart.yml
-    secrets: inherit
-    with:
-      updateVersion: true
-      pushTags: true
-      imageTagName: ${{ inputs.imageTagName }}
-      version: ${{ needs.createVersion.outputs.version }}
-      chartFolder: ${{ inputs.chartFolder }}
-      release_branch: ${{ inputs.release_branch }}
-
-  updateVersionFile:
-    needs: [createVersion, release]
-    uses: ./.github/workflows/job-update-version-file.yml
-    secrets: inherit
-    with:
-      componentVersionKey: ${{ inputs.componentVersionKey }}
-      version: ${{ needs.createVersion.outputs.version }}


### PR DESCRIPTION
…ral repository

The `updateVersionFile` and `release` steps will be replaced with steps in other pipelines in the chart repos. Also we'll add a step to update the charts repo in follow on PR's