### PR TITLE
feat: publish from dist

### DIFF
--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: './'
+      publishFromDist:
+        required: false
+        type: boolean
+        default: false
       release_branch:
         description: 'Name of the release branch'
         required: false
@@ -48,9 +52,11 @@ jobs:
         path: dist
     - name: Publish
       run: |
-        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
+        PUBLISH_DIR="${{ inputs.publishFromDist == 'true' && echo '${{ inputs.workingDirectory }}/dist' || echo '${{ inputs.workingDirectory }}' }}"
+        cd "$PUBLISH_DIR"
+        npm version ${{inputs.version}}
         npm publish
-      working-directory: ${{ inputs.workingDirectory }}
+        cd ..
       env:
         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     # npm version does not commit on subdirectories, so we commit manually
@@ -64,5 +70,6 @@ jobs:
         git tag -a ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
     - name: Push
       run: |
+        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
         git push origin
         git push origin --tags

--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -52,11 +52,10 @@ jobs:
         path: dist
     - name: Publish
       run: |
-        PUBLISH_DIR="${{ inputs.publishFromDist == 'true' && echo '${{ inputs.workingDirectory }}/dist' || echo '${{ inputs.workingDirectory }}' }}"
-        cd "$PUBLISH_DIR"
         npm version ${{inputs.version}}
         npm publish
-        cd ..
+      working-directory:
+        ${{ inputs.publishFromDist ? inputs.workingDirectory + '/dist' : inputs.workingDirectory }}
       env:
         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     # npm version does not commit on subdirectories, so we commit manually
@@ -73,3 +72,4 @@ jobs:
         npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
         git push origin
         git push origin --tags
+      working-directory: ${{ inputs.workingDirectory }}

--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -10,6 +10,10 @@ on:
         required: false
         type: string
         default: './'
+      workingDirectoryDist:
+        required: false
+        type: string
+        default: './dist'
       publishFromDist:
         required: false
         type: boolean
@@ -55,7 +59,7 @@ jobs:
         npm version ${{inputs.version}}
         npm publish
       working-directory:
-        ${{ inputs.publishFromDist ? inputs.workingDirectory + '/dist' : inputs.workingDirectory }}
+        ${{ inputs.publishFromDist && inputs.workingDirectoryDist || inputs.workingDirectory }}
       env:
         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     # npm version does not commit on subdirectories, so we commit manually

--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -54,12 +54,24 @@ jobs:
       with:
         name: target
         path: dist
-    - name: Publish
+    - name: Publish from dist folder
+      if: ${{ inputs.publishFromDist }}
       run: |
-        npm version ${{inputs.version}}
+        npm version ${{ inputs.version }}
+        npm publish
+        cd ..
+        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
+      working-directory:
+        ${{ inputs.workingDirectoryDist }}
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Publish
+      if: ${{ !inputs.publishFromDist }}
+      run: |
+        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
         npm publish
       working-directory:
-        ${{ inputs.publishFromDist && inputs.workingDirectoryDist || inputs.workingDirectory }}
+        ${{ inputs.workingDirectory }}
       env:
         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     # npm version does not commit on subdirectories, so we commit manually
@@ -73,7 +85,6 @@ jobs:
         git tag -a ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
     - name: Push
       run: |
-        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
         git push origin
         git push origin --tags
       working-directory: ${{ inputs.workingDirectory }}

--- a/.github/workflows/pipeline-node-module.yml
+++ b/.github/workflows/pipeline-node-module.yml
@@ -6,6 +6,10 @@ on:
         required: false
         type: string
         default: './'
+      publishFromDist:
+        required: false
+        type: boolean
+        default: false
       release_branch:
         description: 'Name of the release branch'
         required: false
@@ -35,6 +39,7 @@ jobs:
     with:
       version: ${{ needs.createVersion.outputs.version }}
       workingDirectory: ${{ inputs.workingDirectory }}
+      publishFromDist: ${{ inputs.publishFromDist }}
       release_branch: ${{ inputs.release_branch }}
       node_version: ${{ inputs.node_version }}
 


### PR DESCRIPTION
Fix the issue with double versionning with the same version resulting in an error

```
Run npm version v0.14.0 -m "[no ci] Release v0.14.0"
npm error Version not changed
```