### PR TITLE
fix(chart): allow definition of chart repos to fix linting step

### DIFF
--- a/.github/workflows/job-test-chart.yml
+++ b/.github/workflows/job-test-chart.yml
@@ -7,6 +7,10 @@ on:
         required: false
         default: ''
         type: string
+      chartRepos:
+        required: false
+        type: string
+        default: ''
       chartsFolder:
         required: false
         type: string
@@ -53,11 +57,11 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }})
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }} --chart-repos=${{ inputs.chartRepos }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }} --validate-maintainers=false
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }} --validate-maintainers=false --chart-repos=${{ inputs.chartRepos }}
   

--- a/.github/workflows/pipeline-chart.yml
+++ b/.github/workflows/pipeline-chart.yml
@@ -5,6 +5,10 @@ on:
       imageTagName:
         required: true
         type: string
+      chartRepos:
+        required: false
+        type: string
+        default: ''
       chartFolder:
         required: false
         type: string
@@ -52,5 +56,6 @@ jobs:
       pushTags: ${{ inputs.pushTags }}
       updateImageTag: false
       chartFolder: ${{ inputs.chartFolder }}/${{ inputs.chartName }}
+      chartRepos: ${{ inputs.chartRepos }}
       release_branch: ${{ inputs.release_branch }}
       imageTagName: ${{ inputs.imageTagName }}


### PR DESCRIPTION
Currently chart linting is failing because the helm installation in the github action does not now about other repos outside of ghcr. This PR allows adding repos to the ct linting step so it will stop failing

<img width="1299" alt="Screenshot 2024-09-25 at 10 41 17" src="https://github.com/user-attachments/assets/b79c92e7-7027-4e6d-aac5-200e5f293e48">
