### PR TITLE
fix: removed invalid flag

### DIFF
--- a/.github/workflows/job-test-chart.yml
+++ b/.github/workflows/job-test-chart.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }} --chart-repos=${{ inputs.chartRepos }})
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
`--chart-repos` flag is present at `ct lint` but absent at `ct list-chagned` command.
So I removed it from that command.