### PR TITLE
fix: private-key-repo-scope

### DIFF
--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -32,6 +32,7 @@ jobs:
          repositories: |
            ${{ inputs.chartName }}
            helm-charts
+           helm-charts-priv
       - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ inputs.appVersion }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Extend private key scope for triggering remote workflow to include `helm-charts-priv` repository.