### PR TITLE
feat: set continue-on-error: true for download artefact 

### DIFF
--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -54,6 +54,7 @@ jobs:
       with:
         name: target
         path: dist
+      continue-on-error: true
     - name: Publish from dist folder
       if: ${{ inputs.publishFromDist }}
       run: |


### PR DESCRIPTION
in case we build the typescript-configs, there is no dist folder, nor nothing upload while building