### PR TITLE
feat (pipeline-golang-app.yml): add doubleTagging toggle

### DIFF
--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -17,6 +17,10 @@ on:
         required: false
         default: 'openmfp/helm-charts-priv'
         type: string
+      removeAppversionPrefixV:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   trigger-helm-charts-version-update:
@@ -33,6 +37,12 @@ jobs:
            ${{ inputs.chartName }}
            helm-charts
            helm-charts-priv
-      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ inputs.appVersion }}
+      - name: Remove 'v' prefix from appVersion
+        if: ${{ inputs.removeAppversionPrefixV }}
+        run: |
+          appVersion=${{ inputs.appVersion }}
+          appVersion=${appVersion#v}
+          echo "::set-output name=cleaned_appVersion::$appVersion"
+      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -44,7 +44,6 @@ jobs:
           appVersion=${{ inputs.appVersion }}
           appVersion=${appVersion#v}
           echo "::set-output name=cleaned_appVersion::$appVersion"
-      - run: echo "appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}"
-      # - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -17,10 +17,6 @@ on:
         required: false
         default: 'openmfp/helm-charts-priv'
         type: string
-      removeAppversionPrefixV:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   trigger-helm-charts-version-update:
@@ -37,13 +33,6 @@ jobs:
            ${{ inputs.chartName }}
            helm-charts
            helm-charts-priv
-      - name: Remove 'v' prefix from appVersion
-        id: remove-prefix
-        if: ${{ inputs.removeAppversionPrefixV }}
-        run: |
-          appVersion=${{ inputs.appVersion }}
-          appVersion=${appVersion#v}
-          echo "::set-output name=cleaned_appVersion::$appVersion"
-      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
+      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ inputs.appVersion }}
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -44,6 +44,7 @@ jobs:
           appVersion=${{ inputs.appVersion }}
           appVersion=${appVersion#v}
           echo "::set-output name=cleaned_appVersion::$appVersion"
-      - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - run: echo "appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}"
+      # - run: gh workflow run update-chart-parameters.yaml --repo ${{ inputs.targetRepository }} --field chart=${{ inputs.chart }} --field appVersion=${{ steps.remove-prefix.outputs.cleaned_appVersion || inputs.appVersion }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/job-chart-version-update.yml
+++ b/.github/workflows/job-chart-version-update.yml
@@ -38,6 +38,7 @@ jobs:
            helm-charts
            helm-charts-priv
       - name: Remove 'v' prefix from appVersion
+        id: remove-prefix
         if: ${{ inputs.removeAppversionPrefixV }}
         run: |
           appVersion=${{ inputs.appVersion }}

--- a/.github/workflows/job-create-version.yml
+++ b/.github/workflows/job-create-version.yml
@@ -32,12 +32,12 @@ jobs:
           original_string=${{ steps.get-latest-tag.outputs.tag }}
           prefix=${{ inputs.prefix }}
           result=${original_string#"$prefix"}
-          echo "::set-output name=cleaned_string::$result"
+          echo "cleaned_string=$result"
       - name: Get New Version
         id: bump-semver
         uses: WyriHaximus/github-action-next-semvers@v1
         with:
           strict: false
-          version: ${{ steps.remove-prefix.outputs.cleaned_string }}
+          version: ${{ env.cleaned_string }}
     outputs:
       version: ${{ inputs.prefix }}${{ steps.bump-semver.outputs.minor }}

--- a/.github/workflows/job-create-version.yml
+++ b/.github/workflows/job-create-version.yml
@@ -32,7 +32,7 @@ jobs:
           original_string=${{ steps.get-latest-tag.outputs.tag }}
           prefix=${{ inputs.prefix }}
           result=${original_string#"$prefix"}
-          echo "cleaned_string=$result"
+          echo "cleaned_string=$result" >> $GITHUB_ENV
       - name: Get New Version
         id: bump-semver
         uses: WyriHaximus/github-action-next-semvers@v1

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -33,7 +33,7 @@ on:
         required: false
         type: string
         default: 'openmfp/helm-charts-priv'
-      pushPrevixedTag:
+      doubleTagging:
         required: false
         type: boolean
         default: false
@@ -113,15 +113,17 @@ jobs:
       appVersion: ${{ needs.createVersion.outputs.version }}
       chart: ${{ github.event.repository.name }}
       targetRepository: ${{ inputs.repoVersionUpdate }}
-      removeAppversionPrefixV: ${{ inputs.removeAppversionPrefixV }}
 
   pushPrefixedGHTag:
+    runs-on: ubuntu-latest
     needs: [createVersion]
     steps:
       - name: Publish Prefixed GH Tag
-        if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.pushPrevixedTag == true }}
+        id: push-prefixed-gh-tag
+        if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
         # uses: thejeff77/action-push-tag@v1.0.0
         # with:
         #   tag: v${{ inputs.version }}
         #   message: 'v${{ inputs.version }}'
-        run:
+        run: |
+          echo v${{ needs.createVersion.outputs.version }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: 'openmfp/helm-charts-priv'
+      versionPrefix:
+        description: The Prefix to the created version
+        default: "[0-9]"
+        type: string
+        required: false
     outputs:
       version:
         description: "The created Version"
@@ -70,13 +75,17 @@ on:
         required: false
         type: string
         default: 'openmfp/helm-charts-priv'
+      removeAppversionPrefixV:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   createVersion:
     uses: ./.github/workflows/job-create-version.yml
     secrets: inherit
     with:
-      prefix: v
+      prefix: ${{ inputs.versionPrefix || 'useLocalCoverageConfig[0-9]' }}
   
   lint:
     uses: ./.github/workflows/job-golang-lint.yml
@@ -111,3 +120,4 @@ jobs:
       appVersion: ${{ needs.createVersion.outputs.version }}
       chart: ${{ github.event.repository.name }}
       targetRepository: ${{ inputs.repoVersionUpdate }}
+      removeAppversionPrefixV: ${{ inputs.removeAppversionPrefixV }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ inputs.doubleTagging == true }}
         run: |
           echo "Creating second tag"
-          result = ${{ needs.createVersion.outputs.version }}
+          result=${{ needs.createVersion.outputs.version }}
           if [[ $result == v* ]]; then
             result=${result:1}
           else

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -120,7 +120,8 @@ jobs:
     steps:
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
-        if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
+        if: ${{ inputs.doubleTagging == true }}
+        # if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
         # uses: thejeff77/action-push-tag@v1.0.0
         # with:
         #   tag: v${{ inputs.version }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -123,20 +123,16 @@ jobs:
         if: ${{ inputs.doubleTagging == true }}
         run: |
           echo "Creating second tag"
-          result=${{ needs.createVersion.outputs.version }}
+          result="${{ needs.createVersion.outputs.version }}"
           if [[ $result == v* ]]; then
-            result=${result:1}
+            result="${result:1}"
           else
             result="v$result"
           fi
-          echo "::set-output name=secondtag_string::$result"
+          echo "secondtag_string=$result" >> $GITHUB_ENV
+
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
         if: ${{ inputs.doubleTagging == true }}
-        # if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
-        # uses: thejeff77/action-push-tag@v1.0.0
-        # with:
-        #   tag: v${{ inputs.version }}
-        #   message: 'v${{ inputs.version }}'
         run: |
-          echo v${{ steps.create-second-tag.outputs.secondtag_string }}
+          echo "v${{ env.secondtag_string }}"

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -85,7 +85,7 @@ jobs:
     uses: ./.github/workflows/job-create-version.yml
     secrets: inherit
     with:
-      prefix: ${{ inputs.versionPrefix || 'useLocalCoverageConfig[0-9]' }}
+      prefix: ${{ inputs.versionPrefix }}
   
   lint:
     uses: ./.github/workflows/job-golang-lint.yml
@@ -113,7 +113,7 @@ jobs:
 
   updateVersion:
     needs: [createVersion, dockerBuildAndPush]
-    if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) }}
+    # if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) }}
     uses: ./.github/workflows/job-chart-version-update.yml
     secrets: inherit
     with:

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ inputs.doubleTagging == true }}
         run: |
           echo "Creating second tag"
-          result="v${{ needs.createVersion.outputs.version }}"
+          result="${{ needs.createVersion.outputs.version }}"
           if [[ $result == v* ]]; then
             result="${result:1}"
           else

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -117,11 +117,10 @@ jobs:
   pushPrefixedGHTag:
     runs-on: ubuntu-latest
     needs: [createVersion]
-    if: ${{ inputs.doubleTagging == true }}
+    if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && (inputs.doubleTagging == true) }}
     steps:
       - name: Create second tag
         id: create-second-tag
-        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) }}
         run: |
           echo "Creating second tag"
           result="${{ needs.createVersion.outputs.version }}"
@@ -134,7 +133,6 @@ jobs:
 
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
-        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) }}
         uses: thejeff77/action-push-tag@v1.0.0
         with:
           tag: ${{ env.secondtag_string }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Create second tag
         id: create-second-tag
-        if: ${{ inputs.doubleTagging == true }}
+        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
         run: |
           echo "Creating second tag"
           result="${{ needs.createVersion.outputs.version }}"
@@ -133,6 +133,8 @@ jobs:
 
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
-        if: ${{ inputs.doubleTagging == true }}
-        run: |
-          echo "${{ env.secondtag_string }}"
+        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
+        uses: thejeff77/action-push-tag@v1.0.0
+        with:
+          tag: ${{ env.secondtag_string }}
+          message: '${{ env.secondtag_string }}'

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -75,6 +75,8 @@ jobs:
   createVersion:
     uses: ./.github/workflows/job-create-version.yml
     secrets: inherit
+    with:
+      prefix: v
   
   lint:
     uses: ./.github/workflows/job-golang-lint.yml

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -118,6 +118,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: [createVersion]
     steps:
+      - name: Create second tag
+        id: create-second-tag
+        if: ${{ inputs.doubleTagging == true }}
+        run: |
+          echo "Creating second tag"
+          result = ${{ needs.createVersion.outputs.version }}
+          if [[ $result == v* ]]; then
+            result=${result:1}
+          else
+            result="v$result"
+          fi
+          echo "::set-output name=secondtag_string::$result"
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
         if: ${{ inputs.doubleTagging == true }}
@@ -127,4 +139,4 @@ jobs:
         #   tag: v${{ inputs.version }}
         #   message: 'v${{ inputs.version }}'
         run: |
-          echo v${{ needs.createVersion.outputs.version }}
+          echo v${{ needs.create-second-tag.outputs.secondtag_string }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -139,4 +139,4 @@ jobs:
         #   tag: v${{ inputs.version }}
         #   message: 'v${{ inputs.version }}'
         run: |
-          echo v${{ needs.create-second-tag.outputs.secondtag_string }}
+          echo v${{ steps.create-second-tag.outputs.secondtag_string }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -135,4 +135,4 @@ jobs:
         id: push-prefixed-gh-tag
         if: ${{ inputs.doubleTagging == true }}
         run: |
-          echo "v${{ env.secondtag_string }}"
+          echo "${{ env.secondtag_string }}"

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -117,10 +117,11 @@ jobs:
   pushPrefixedGHTag:
     runs-on: ubuntu-latest
     needs: [createVersion]
+    if: ${{ inputs.doubleTagging == true }}
     steps:
       - name: Create second tag
         id: create-second-tag
-        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
+        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) }}
         run: |
           echo "Creating second tag"
           result="${{ needs.createVersion.outputs.version }}"
@@ -133,7 +134,7 @@ jobs:
 
       - name: Publish Prefixed GH Tag
         id: push-prefixed-gh-tag
-        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.doubleTagging == true }}
+        if: ${{  github.ref == format('refs/heads/{0}',inputs.release_branch) }}
         uses: thejeff77/action-push-tag@v1.0.0
         with:
           tag: ${{ env.secondtag_string }}

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -123,7 +123,7 @@ jobs:
         if: ${{ inputs.doubleTagging == true }}
         run: |
           echo "Creating second tag"
-          result="${{ needs.createVersion.outputs.version }}"
+          result="v${{ needs.createVersion.outputs.version }}"
           if [[ $result == v* ]]; then
             result="${result:1}"
           else

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -33,12 +33,7 @@ on:
         required: false
         type: string
         default: 'openmfp/helm-charts-priv'
-      versionPrefix:
-        description: The Prefix to the created version
-        default: "[0-9]"
-        type: string
-        required: false
-      removeAppversionPrefixV:
+      pushPrevixedTag:
         required: false
         type: boolean
         default: false
@@ -84,8 +79,6 @@ jobs:
   createVersion:
     uses: ./.github/workflows/job-create-version.yml
     secrets: inherit
-    with:
-      prefix: ${{ inputs.versionPrefix }}
   
   lint:
     uses: ./.github/workflows/job-golang-lint.yml
@@ -113,7 +106,7 @@ jobs:
 
   updateVersion:
     needs: [createVersion, dockerBuildAndPush]
-    # if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) }}
+    if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) }}
     uses: ./.github/workflows/job-chart-version-update.yml
     secrets: inherit
     with:
@@ -121,3 +114,14 @@ jobs:
       chart: ${{ github.event.repository.name }}
       targetRepository: ${{ inputs.repoVersionUpdate }}
       removeAppversionPrefixV: ${{ inputs.removeAppversionPrefixV }}
+
+  pushPrefixedGHTag:
+    needs: [createVersion]
+    steps:
+      - name: Publish Prefixed GH Tag
+        if: ${{ github.ref == format('refs/heads/{0}',inputs.release_branch) && inputs.pushPrevixedTag == true }}
+        # uses: thejeff77/action-push-tag@v1.0.0
+        # with:
+        #   tag: v${{ inputs.version }}
+        #   message: 'v${{ inputs.version }}'
+        run:

--- a/.github/workflows/pipeline-golang-app.yml
+++ b/.github/workflows/pipeline-golang-app.yml
@@ -38,6 +38,10 @@ on:
         default: "[0-9]"
         type: string
         required: false
+      removeAppversionPrefixV:
+        required: false
+        type: boolean
+        default: false
     outputs:
       version:
         description: "The created Version"
@@ -75,10 +79,6 @@ on:
         required: false
         type: string
         default: 'openmfp/helm-charts-priv'
-      removeAppversionPrefixV:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   createVersion:


### PR DESCRIPTION
Add parameter `doubleTagging` in **pipeline-golang-app.yml** which, when **true** will push 2 GH Tags with and without the `v` prefix. For respositories which already have both types of tags with and without prefix (especially different version increments), the latest version will be calculated by default by getting the newest tag without `v` prefix.

Changes:
- implement doubleTagging toggle
- migrate deprecated `::set-output` to GITHUB_ENV