### PR TITLE
fix(workflows): retrieve npm version from package.json before publishing

### DIFF
--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -73,10 +73,16 @@ jobs:
         ${{ inputs.workingDirectoryDist }}
       env:
         NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Get New Version
+      id: bump-semver
+      uses: WyriHaximus/github-action-next-semvers@v1
+      with:
+        strict: false
+        version: ${{ env.npm_version }}
     - name: Publish
       if: ${{ !inputs.publishFromDist }}
       run: |
-        npm version ${{ env.npm_version }} -m "[no ci] Release ${{ env.npm_version }}"
+        npm version ${{ steps.bump-semver.outputs.minor }} -m "[no ci] Release ${{ steps.bump-semver.outputs.minor }}"
         npm publish
       working-directory:
         ${{ inputs.workingDirectory }}
@@ -87,10 +93,10 @@ jobs:
       if: inputs.workingDirectory != './'
       run: |
         git add .
-        git commit -m "[no ci] Release ${{inputs.version}}"
+        git commit -m "[no ci] Release ${{ steps.bump-semver.outputs.minor }}"
         git fetch
         git rebase
-        git tag -a ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
+        git tag -a ${{ steps.bump-semver.outputs.minor }} -m "[no ci] Release ${{ steps.bump-semver.outputs.minor }}"
     - name: Push
       run: |
         git push origin

--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -55,13 +55,20 @@ jobs:
         name: target
         path: dist
       continue-on-error: true
+    - name: Get npm version
+      id: get-npm-version
+      run: |
+        NPM_VERSION=$(cat ${{ inputs.workingDirectory }}/package.json | jq '.version' -r)
+        echo "NPM version: $NPM_VERSION"
+        echo "npm_version=$NPM_VERSION" >> $GITHUB_ENV
+      working-directory: ${{ inputs.workingDirectory }}
     - name: Publish from dist folder
       if: ${{ inputs.publishFromDist }}
       run: |
-        npm version ${{ inputs.version }}
+        npm version ${{ env.npm_version }}
         npm publish
         cd ..
-        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
+        npm version ${{ env.npm_version }} -m "[no ci] Release ${{ env.npm_version }}"
       working-directory:
         ${{ inputs.workingDirectoryDist }}
       env:
@@ -69,7 +76,7 @@ jobs:
     - name: Publish
       if: ${{ !inputs.publishFromDist }}
       run: |
-        npm version ${{inputs.version}} -m "[no ci] Release ${{inputs.version}}"
+        npm version ${{ env.npm_version }} -m "[no ci] Release ${{ env.npm_version }}"
         npm publish
       working-directory:
         ${{ inputs.workingDirectory }}

--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Get npm version
       id: get-npm-version
       run: |
-        NPM_VERSION=$(cat ${{ inputs.workingDirectory }}/package.json | jq '.version' -r)
+        NPM_VERSION=$(cat package.json | jq '.version' -r)
         echo "NPM version: $NPM_VERSION"
         echo "npm_version=$NPM_VERSION" >> $GITHUB_ENV
       working-directory: ${{ inputs.workingDirectory }}


### PR DESCRIPTION
Repositories which contain >1 npm packages use the git repo tag to determine the NPM version, which can lead to conflicts. Here we switch to bumping the latest NPM version from the repository, which should be unique for each pkg to resolve this.