### PR TITLE
fix(lint): only lint the current chart instead of the entire folder

### DIFF
--- a/.github/workflows/job-test-chart.yml
+++ b/.github/workflows/job-test-chart.yml
@@ -69,5 +69,5 @@ jobs:
           fi
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }} --validate-maintainers=false --chart-repos=${{ inputs.chartRepos }}
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=${{ inputs.chartsFolder }}/${{ inputs.chartName }} --validate-maintainers=false --chart-repos=${{ inputs.chartRepos }}
   


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/job-test-chart.yml` file. The change modifies the `run` command for the chart-testing (lint) step to specify a particular chart directory by appending the chart name to the chart directory path.

* [`.github/workflows/job-test-chart.yml`](diffhunk://#diff-32b79465726a4ccb2e4025800b8bf43e748390cd171f4cbc0471d0b3a8506481L72-R72): Updated the `run` command in the chart-testing (lint) step to include the chart name in the chart directory path.