### PR TITLE
fix: prevent command injection in release-openmfp workflow

### DIFF
--- a/.github/workflows/release-openmfp.yml
+++ b/.github/workflows/release-openmfp.yml
@@ -23,10 +23,12 @@ jobs:
             portal-ui-lib
             portal-server-lib
       - name: Release portal-ui-lib
-        run: gh workflow run release.yml --repo openmfp/portal-ui-lib --field version="${{ inputs.version }}"
+        run: gh workflow run release.yml --repo openmfp/portal-ui-lib --field version="$VERSION"
         env:
+          VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Release portal-server-lib
-        run: gh workflow run release.yml --repo openmfp/portal-server-lib --field version="${{ inputs.version }}"
+        run: gh workflow run release.yml --repo openmfp/portal-server-lib --field version="$VERSION"
         env:
+          VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Fixes command injection vulnerability in `release-openmfp.yml` where `inputs.version` was interpolated directly into `run:` shell scripts
- Passes the version through an environment variable (`$VERSION`) instead, so shell metacharacters in the input are not interpreted

## Context
Review finding from PR #226 — `${{ inputs.version }}` in a `run:` block allows arbitrary command execution via crafted `workflow_dispatch` input.