### PR TITLE
fix: ensure sequential release execution with failure gating

### DIFF
--- a/.github/workflows/release-openmfp.yml
+++ b/.github/workflows/release-openmfp.yml
@@ -23,12 +23,48 @@ jobs:
             portal-ui-lib
             portal-server-lib
       - name: Release portal-ui-lib
-        run: gh workflow run release.yml --repo openmfp/portal-ui-lib --field version="$VERSION"
+        run: |
+          BEFORE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          gh workflow run release.yml --repo openmfp/portal-ui-lib --field version="$VERSION"
+
+          RUN_ID=""
+          for i in $(seq 1 30); do
+            sleep 2
+            RUN_ID=$(gh run list --repo openmfp/portal-ui-lib --workflow release.yml \
+              --json databaseId,createdAt --jq "[.[] | select(.createdAt >= \"$BEFORE\")] | .[0].databaseId")
+            if [ -n "$RUN_ID" ]; then break; fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Failed to find triggered run for portal-ui-lib"
+            exit 1
+          fi
+
+          echo "Watching run $RUN_ID"
+          gh run watch "$RUN_ID" --repo openmfp/portal-ui-lib --exit-status
         env:
           VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Release portal-server-lib
-        run: gh workflow run release.yml --repo openmfp/portal-server-lib --field version="$VERSION"
+        run: |
+          BEFORE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          gh workflow run release.yml --repo openmfp/portal-server-lib --field version="$VERSION"
+
+          RUN_ID=""
+          for i in $(seq 1 30); do
+            sleep 2
+            RUN_ID=$(gh run list --repo openmfp/portal-server-lib --workflow release.yml \
+              --json databaseId,createdAt --jq "[.[] | select(.createdAt >= \"$BEFORE\")] | .[0].databaseId")
+            if [ -n "$RUN_ID" ]; then break; fi
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::Failed to find triggered run for portal-server-lib"
+            exit 1
+          fi
+
+          echo "Watching run $RUN_ID"
+          gh run watch "$RUN_ID" --repo openmfp/portal-server-lib --exit-status
         env:
           VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- `gh workflow run` is fire-and-forget — it returns immediately without waiting for the triggered run
- This change records a timestamp before triggering, polls for the newly created run ID, then uses `gh run watch --exit-status` to block until completion
- If `portal-ui-lib` release fails, `portal-server-lib` is never triggered

## Context
Review finding #3 from PR #226 — the PR description claimed sequential execution with failure gating, but both repos were triggered in parallel with no waiting.