### PR TITLE
fix: add permissions block and forward release_branch input

### DIFF
--- a/.github/workflows/job-release-node.yml
+++ b/.github/workflows/job-release-node.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: string
         default: './'
+      release_branch:
+        description: 'Name of the release branch'
+        required: false
+        type: string
+        default: 'main'
       publishFromDist:
         required: false
         type: boolean
@@ -55,6 +60,7 @@ jobs:
     secrets: inherit
     with:
       workingDirectory: ${{ inputs.workingDirectory }}
+      release_branch: ${{ inputs.release_branch }}
       artifactPath: ${{ inputs.artifactPath }}
       hasBuild: ${{ inputs.hasBuild }}
       node_version: ${{ inputs.node_version }}

--- a/.github/workflows/release-openmfp.yml
+++ b/.github/workflows/release-openmfp.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   trigger-releases:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: {}` to `release-openmfp.yml` to restrict default `GITHUB_TOKEN` scope (least privilege)
- Add `release_branch` input to `job-release-node.yml` and forward it to `job-node-test.yml` so artifact uploads work for non-main branches

Addresses review comments on #226.