### PR TITLE
chore: add skipVersionCommit flag to job-node-publish

### DIFF
--- a/.github/workflows/job-node-publish.yml
+++ b/.github/workflows/job-node-publish.yml
@@ -40,6 +40,11 @@ on:
         description: 'The environment to use'
         required: true
         type: string
+      skipVersionCommit:
+        description: 'Whether to skip the version commit and push'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   publish:
@@ -88,13 +93,14 @@ jobs:
       working-directory:
         ${{ inputs.workingDirectory }}
     - name: Commit and Tag
-      if: inputs.workingDirectory != './'
+      if: ${{ inputs.workingDirectory != './' && !inputs.skipVersionCommit }}
       run: |
         git add .
         git commit -m "[no ci] Release ${{ env.CLEANED_VERSION }}"
         git fetch
         git rebase
     - name: Push
+      if: ${{ !inputs.skipVersionCommit }}
       run: |
         git push origin
       working-directory: ${{ inputs.workingDirectory }}


### PR DESCRIPTION
## Summary
- Adds a `skipVersionCommit` input (default: `false`) to `job-node-publish.yml`
- When `true`, skips the version commit and push steps after publishing
- Useful for repos that publish multiple packages from the same build and only need one version commit

## Test plan
- Existing workflows unchanged (default `false` preserves current behavior)
- Callers can pass `skipVersionCommit: true` to suppress the commit/push